### PR TITLE
docs: add warning to save private key in SSH setup step

### DIFF
--- a/src/docs/onboarding/onboarding.md
+++ b/src/docs/onboarding/onboarding.md
@@ -14,6 +14,10 @@ to get your services deployed smoothly.
 
 ## Step 1: Add SSH Keys
 
+> ⚠️ **Important:** Make sure to securely save your private key when adding it. 
+> If you lose it or disconnect from the server, you may not be able to reconnect without it.
+> It's recommended to store it in a secure password manager or local vault.
+
 The first step in the onboarding process is to set up your SSH keys. These keys
 are essential for establishing secure connections between dFlow and your
 servers.


### PR DESCRIPTION
## 📝 What I Did

- Updated `onboarding.md` documentation file.
- Added a warning for users to **securely save their private key** during SSH key setup.

## 🧠 Why I Did It

- Currently, the onboarding doc doesn't inform users that losing the private key will block access to the server.
- This addition makes the onboarding process more robust and user-aware.

## 🗂️ File Changed

- `src/docs/onboarding/onboarding.md`

## 📌 Note

- No functional or code changes made — only documentation.
