### PR TITLE
feat: add global build directory configuration for Dokku applications

### DIFF
--- a/src/actions/server/validator.ts
+++ b/src/actions/server/validator.ts
@@ -96,3 +96,8 @@ export const checkServerConnectionSchema = z.discriminatedUnion(
 export const generateTailscaleHostnameSchema = z.object({
   hostname: z.string(),
 })
+
+export const configureGlobalBuildDirSchema = z.object({
+  serverId: z.string(),
+  buildDir: z.string().optional(),
+})

--- a/src/app/(frontend)/(dashboard)/[organisation]/servers/[id]/layout.client.tsx
+++ b/src/app/(frontend)/(dashboard)/[organisation]/servers/[id]/layout.client.tsx
@@ -25,6 +25,7 @@ const tabsList = [
   { label: 'Plugins', slug: 'plugins', disabled: false },
   { label: 'Domains', slug: 'domains', disabled: false },
   { label: 'Monitoring', slug: 'monitoring', disabled: false },
+  { label: 'Settings', slug: 'settings', disabled: false },
 ] as const
 
 const LayoutClient = ({
@@ -44,6 +45,7 @@ const LayoutClient = ({
       'monitoring',
       'plugins',
       'domains',
+      'settings',
     ]).withDefault('general'),
   )
 

--- a/src/app/(frontend)/(dashboard)/[organisation]/servers/[id]/page.tsx
+++ b/src/app/(frontend)/(dashboard)/[organisation]/servers/[id]/page.tsx
@@ -2,6 +2,7 @@ import {
   AlertCircle,
   ScreenShareOff,
   Server,
+  Settings2,
   TriangleAlert,
 } from 'lucide-react'
 import { notFound } from 'next/navigation'
@@ -20,6 +21,7 @@ import ConnectionErrorBanner from '@/components/servers/ConnectionErrorBanner'
 import UpdateEC2InstanceForm from '@/components/servers/CreateEC2InstanceForm'
 import DomainForm from '@/components/servers/DomainForm'
 import DomainList from '@/components/servers/DomainList'
+import GlobalBuildDirForm from '@/components/servers/GlobalBuildDirForm'
 import PluginsList from '@/components/servers/PluginsList'
 import { ProjectsAndServicesSection } from '@/components/servers/ProjectsAndServices'
 import ProvisioningBanner from '@/components/servers/ProvisioningBanner'
@@ -275,6 +277,26 @@ const BannerLayout = ({
   )
 }
 
+const ServerSettingsTab = ({ server }: { server: ServerType }) => {
+  return (
+    <div className='space-y-6'>
+      <SSHConnectionAlert server={server} />
+
+      <div className='space-y-4'>
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-1.5'>
+            <Settings2 />
+            <h4 className='text-lg font-semibold'>Server Settings</h4>
+          </div>
+
+          <RefreshButton showText={true} text='Refresh Server Status' />
+        </div>
+        <GlobalBuildDirForm server={server} />
+      </div>
+    </div>
+  )
+}
+
 const SuspendedPage = ({ params, searchParams }: PageProps) => {
   const [syncParams, syncSearchParams] = use(
     Promise.all([params, searchParams]),
@@ -327,6 +349,9 @@ const SuspendedPage = ({ params, searchParams }: PageProps) => {
             />
           </Suspense>
         )
+
+      case 'settings':
+        return <ServerSettingsTab server={server} />
 
       default:
         return (

--- a/src/components/servers/GlobalBuildDirForm.tsx
+++ b/src/components/servers/GlobalBuildDirForm.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+import { Alert, AlertDescription, AlertTitle } from '../ui/alert'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../ui/card'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { Separator } from '../ui/separator'
+import { AlertTriangle, Check, FolderOpen, RotateCcw } from 'lucide-react'
+import { useAction } from 'next-safe-action/hooks'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { configureGlobalBuildDirAction } from '@/actions/server'
+import { Server } from '@/payload-types'
+
+const GlobalBuildDirForm = ({ server }: { server: Server }) => {
+  const [buildDir, setBuildDir] = useState(server.globalBuildPath || '')
+
+  const { execute, isPending } = useAction(configureGlobalBuildDirAction, {
+    onSuccess: result => {
+      if (result?.data?.success) {
+        toast.success('Global build path updated!')
+      } else {
+        toast.error('Failed to update build path', {
+          description: result?.data?.message,
+        })
+      }
+    },
+    onError: error => {
+      toast.error('Failed to update build path', {
+        description: error?.error?.serverError,
+      })
+    },
+  })
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // Remove leading slash if present
+    const value = e.target.value.replace(/^\/+/, '')
+    setBuildDir(value)
+  }
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    execute({ serverId: server.id, buildDir })
+  }
+
+  const handleReset = () => {
+    setBuildDir('/')
+    execute({ serverId: server.id, buildDir: '/' })
+  }
+
+  const displayValue = buildDir || '/'
+  const isDefaultPath = !buildDir
+
+  return (
+    <Card className='w-full'>
+      <CardHeader>
+        <div className='flex items-center gap-2'>
+          <FolderOpen className='h-5 w-5' />
+          <CardTitle>Global Build Directory</CardTitle>
+          {!isDefaultPath && (
+            <Badge variant='secondary' className='ml-auto'>
+              Custom Path
+            </Badge>
+          )}
+        </div>
+        <CardDescription>
+          Set the global default build directory for all Dokku applications on
+          this server. Individual apps can override this with app-specific
+          settings.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className='space-y-6'>
+        {buildDir && buildDir !== '/' && (
+          <Alert variant='warning'>
+            <AlertTriangle className='h-4 w-4' />
+            <AlertTitle>Warning</AlertTitle>
+            <AlertDescription>
+              Setting a custom build directory will result in loss of any
+              changes to the top-level directory, such as the{' '}
+              <code className='rounded bg-muted px-1'>git.keep-git-dir</code>{' '}
+              property. Make sure this is the intended behavior for your
+              deployment.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <form onSubmit={handleSave} className='space-y-4'>
+          <div className='space-y-2'>
+            <Label htmlFor='buildDir' className='flex items-center gap-2'>
+              Global Build Directory
+              <span className='text-xs text-muted-foreground'>
+                (current:{' '}
+                <code className='rounded bg-muted px-1 text-xs'>
+                  {displayValue}
+                </code>
+                )
+              </span>
+            </Label>
+            <div className='relative'>
+              <Input
+                id='buildDir'
+                value={buildDir}
+                onChange={handleInputChange}
+                placeholder='e.g. app2, dist, build, apps/backend (leave empty for repository root)'
+                disabled={isPending}
+              />
+              {isDefaultPath && (
+                <div className='absolute right-3 top-1/2 -translate-y-1/2'>
+                  <Check className='h-4 w-4 text-green-500' />
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className='flex justify-end gap-2'>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={handleReset}
+              disabled={
+                isPending ||
+                (!buildDir && !server.globalBuildPath) ||
+                (buildDir === '/' &&
+                  (!server.globalBuildPath || server.globalBuildPath === '/'))
+              }>
+              <RotateCcw className='mr-2 h-4 w-4' />
+              Reset to Default
+            </Button>
+            <Button
+              type='submit'
+              disabled={
+                isPending || buildDir === (server.globalBuildPath || '')
+              }>
+              {isPending ? 'Saving...' : 'Save Configuration'}
+            </Button>
+          </div>
+        </form>
+
+        <Separator />
+
+        <div className='space-y-3 text-sm'>
+          <h4 className='font-medium'>How It Works</h4>
+          <div className='space-y-2 text-muted-foreground'>
+            <div className='flex items-start gap-2'>
+              <code className='min-w-fit rounded bg-muted px-2 py-1 font-mono text-xs'>
+                (empty)
+              </code>
+              <span>
+                Uses the entire repository as the build context. This is the
+                default behavior for most applications.
+              </span>
+            </div>
+            <div className='flex items-start gap-2'>
+              <code className='min-w-fit rounded bg-muted px-2 py-1 font-mono text-xs'>
+                app2
+              </code>
+              <span>
+                Uses only the app2 subdirectory as the build context. Useful
+                when your application code is in a specific folder.
+              </span>
+            </div>
+            <div className='flex items-start gap-2'>
+              <code className='min-w-fit rounded bg-muted px-2 py-1 font-mono text-xs'>
+                apps/backend
+              </code>
+              <span>
+                Uses the apps/backend subdirectory for monorepo setups where
+                different applications are in separate folders.
+              </span>
+            </div>
+            <div className='flex items-start gap-2'>
+              <code className='min-w-fit rounded bg-muted px-2 py-1 font-mono text-xs'>
+                dist
+              </code>
+              <span>
+                Uses the dist folder, typically for applications that have a
+                build step that outputs to a dist directory.
+              </span>
+            </div>
+          </div>
+          <div className='mt-4 rounded-lg bg-muted/50 p-3'>
+            <p className='text-xs text-muted-foreground'>
+              <strong>Note:</strong> Individual apps can override this global
+              setting using app-specific build directory configuration. If the
+              specified directory doesn't exist in the repository, the build
+              will fail.
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default GlobalBuildDirForm

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -463,6 +463,10 @@ export interface Server {
    * Number of times connection to the server has been attempted (DFlow only).
    */
   connectionAttempts?: number | null;
+  /**
+   * Default build directory for all Dokku applications on this server. Leave empty to use repository root.
+   */
+  globalBuildPath?: string | null;
   deletedAt?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -1382,6 +1386,7 @@ export interface ServersSelect<T extends boolean = true> {
         lastChecked?: T;
       };
   connectionAttempts?: T;
+  globalBuildPath?: T;
   deletedAt?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/payload/collections/Servers/index.ts
+++ b/src/payload/collections/Servers/index.ts
@@ -638,5 +638,16 @@ export const Servers: CollectionConfig = {
         ],
       },
     },
+    {
+      name: 'globalBuildPath',
+      type: 'text',
+      label: 'Global Build Path',
+      defaultValue: '/',
+      admin: {
+        description:
+          'Default build directory for all Dokku applications on this server. Leave empty to use repository root.',
+        placeholder: 'e.g. app, dist, build (leave empty for repository root)',
+      },
+    },
   ],
 }


### PR DESCRIPTION
- Introduced a new interface property `globalBuildPath` to define the default build directory for all Dokku applications on the server.
- Implemented `configureGlobalBuildDirAction` to handle updates to the global build directory.
- Added a new `GlobalBuildDirForm` component for user input and management of the global build directory setting.
- Updated server validation schema to include `configureGlobalBuildDirSchema`.
- Enhanced the server settings UI to include a new settings tab for managing the global build directory.